### PR TITLE
Migrates to Container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: ruby
 
+sudo: false
+
+cache: bundler
+
+addons:
+  apt:
+    packages:
+      - libtokyocabinet-dev
+
 rvm:
   - 2.1.0
   - 2.2.3
   - ruby-head
-
-before_install:
-  - sudo apt-get install libtokyocabinet-dev -y
 
 script: bundle exec ruby test/run-test.rb
 


### PR DESCRIPTION
According to travis-ci/apt-package-whitelist#2069, `libtokyocabinet-dev` has been listed as a package supported by [Container-based Infrastructure](https://docs.travis-ci.com/user/migrating-from-legacy/). 

This PR aims to try it :exclamation: 